### PR TITLE
Revert "use timestamps as user identifiers"

### DIFF
--- a/ruby/users/space.rb
+++ b/ruby/users/space.rb
@@ -5,10 +5,43 @@ module Users
   class Space < ::Spaces::Space
 
     def save_yaml(model)
-      model.struct.identifier ||= Time.now.to_i
+      model.struct.identifier ||= next_identifier
       f = File.open("#{file_name_for(model.identifier)}.yaml", 'w')
       begin
         f.write(model.to_yaml)
+      ensure
+        f.close
+      end
+    end
+
+    def next_identifier
+      (first_time? ? seed_identifier : next_running_identifier).tap do |id|
+        increment(id)
+      end
+    end
+
+    def first_time?
+      !File.exist?(file_name_for('next'))
+    end
+
+    def next_running_identifier
+      f = File.open(file_name_for('next'), 'r')
+      begin
+        f.read.strip
+      ensure
+        f.close
+      end
+    end
+
+    def seed_identifier
+      '100000'
+    end
+
+    def increment(identifier)
+      f = File.open(file_name_for('next'), 'w+')
+      begin
+        i = identifier.to_i
+        f.puts(i += 1)
       ensure
         f.close
       end


### PR DESCRIPTION
This reverts commit 773c1bd1786ea6f589885cd24f6282f910eaba79.