### PR TITLE
FIX BUG:  blueprint keyword “path” name-clashes with #path derivation for scripts

### DIFF
--- a/ruby/docker/files/file.rb
+++ b/ruby/docker/files/file.rb
@@ -44,7 +44,7 @@ module Docker
         end
       end
 
-      def path
+      def product_path
         klass.identifier
       end
 

--- a/ruby/frameworks/framework.rb
+++ b/ruby/frameworks/framework.rb
@@ -43,13 +43,13 @@ module Frameworks
       8000
     end
 
-    def path
+    def product_path
       "#{super}/#{klass.identifier}"
     end
 
     def struct
       @struct ||= installation.struct.framework
     end
-    
+
   end
 end

--- a/ruby/frameworks/scripts/finalisation.rb
+++ b/ruby/frameworks/scripts/finalisation.rb
@@ -46,7 +46,7 @@ module Frameworks
       end
 
       def script_file_name
-        "/#{context.path}/#{identifier}.sh"
+        "/#{context.product_path}/#{identifier}.sh"
       end
 
     end

--- a/ruby/images/product.rb
+++ b/ruby/images/product.rb
@@ -15,7 +15,7 @@ module Images
       klass.script_lot
     end
 
-    def path
+    def product_path
       'scripts'
     end
 

--- a/ruby/images/space.rb
+++ b/ruby/images/space.rb
@@ -6,7 +6,7 @@ module Images
     def save(subject)
       subject.product.map do |t|
         save_text(t)
-        "#{t.path}"
+        "#{t.product_path}"
       end
     end
 

--- a/ruby/images/steps/chown_app_dir.rb
+++ b/ruby/images/steps/chown_app_dir.rb
@@ -4,7 +4,7 @@ module Images
   module Steps
     class ChownAppDir < Docker::Files::Step
       def product
-        "RUN #{context.path}/chown_app_dir.sh"
+        "RUN #{context.product_path}/chown_app_dir.sh"
       end
 
     end

--- a/ruby/images/steps/injections.rb
+++ b/ruby/images/steps/injections.rb
@@ -4,7 +4,7 @@ module Images
   module Steps
     class Injections < Docker::Files::Step
       def product
-        "RUN #{context.path}/injections.sh"
+        "RUN #{context.product_path}/injections.sh"
       end
 
     end

--- a/ruby/installations/division.rb
+++ b/ruby/installations/division.rb
@@ -19,7 +19,7 @@ module Installations
       Module.const_get(klass.name.singularize)
     end
 
-    def path
+    def product_path
        "#{super}/#{blueprint_label}"
     end
 

--- a/ruby/installations/product.rb
+++ b/ruby/installations/product.rb
@@ -27,11 +27,11 @@ module Installations
       def inheritance_paths; end
     end
 
-    def path
+    def product_path
       "build/#{super}"
     end
 
-    alias_method :collaborator_path, :path
+    alias_method :collaborator_path, :product_path
 
     def product
       duplicate(struct)

--- a/ruby/installations/subdivision.rb
+++ b/ruby/installations/subdivision.rb
@@ -5,7 +5,7 @@ module Installations
 
     relation_accessor :context
 
-    delegate([:installation, :path, :context_identifier] => :context)
+    delegate([:installation, :product_path, :context_identifier] => :context)
 
     def initialize(struct:, context:)
       self.struct = struct

--- a/ruby/packages/scripts/installation.rb
+++ b/ruby/packages/scripts/installation.rb
@@ -53,9 +53,9 @@ module Packages
         	mv "./#{extracted_path}" #{destination_path}
         fi
 
-        if test -f /#{path}/#{extracted_path}
+        if test -f /#{product_path}/#{extracted_path}
         then
-        	rm -rf /#{path}/#{extracted_path}
+        	rm -rf /#{product_path}/#{extracted_path}
         fi
         )
       end

--- a/ruby/packages/scripts/preparation.rb
+++ b/ruby/packages/scripts/preparation.rb
@@ -6,8 +6,8 @@ module Packages
 
       def body
         %Q(
-        mkdir /#{path}
-        cd /#{path}
+        mkdir /#{product_path}
+        cd /#{product_path}
         )
       end
 

--- a/ruby/texts/file_text.rb
+++ b/ruby/texts/file_text.rb
@@ -19,7 +19,7 @@ module Texts
       end
     end
 
-    def path
+    def product_path
       source_file_name
     end
 

--- a/ruby/texts/script.rb
+++ b/ruby/texts/script.rb
@@ -6,7 +6,7 @@ module Texts
     relation_accessor :context
     attr_reader :product
 
-    delegate([:path, :home_app_path, :identifier, :context_identifier] => :context)
+    delegate([:product_path, :home_app_path, :identifier, :context_identifier] => :context)
 
     def product
       [
@@ -36,7 +36,7 @@ module Texts
     end
 
     def full_path
-      "#{path}/#{file_name}"
+      "#{product_path}/#{file_name}"
     end
 
     def file_name
@@ -44,7 +44,7 @@ module Texts
     end
 
     def subpath
-      "#{context.subpath}/#{path}"
+      "#{context.subpath}/#{product_path}"
     end
 
     def initialize(context)

--- a/ruby/users/steps/setup_user.rb
+++ b/ruby/users/steps/setup_user.rb
@@ -4,7 +4,7 @@ module Users
   module Steps
     class SetupUser < Docker::Files::Step
       def product
-        "RUN #{context.path}/setup_user.sh"
+        "RUN #{context.product_path}/setup_user.sh"
       end
 
     end

--- a/ruby/web_servers/apache/steps/configure.rb
+++ b/ruby/web_servers/apache/steps/configure.rb
@@ -8,7 +8,7 @@ module WebServers
         def product
         %Q(
           USER 0
-          RUN #{context.path}/configure.sh
+          RUN #{context.product_path}/configure.sh
         )
         end
 


### PR DESCRIPTION


renamed to #product_path