### PR TITLE
FIX BUG: an installation’s blueprint_identifier could get blown away …

### DIFF
--- a/ruby/installations/installation.rb
+++ b/ruby/installations/installation.rb
@@ -31,7 +31,7 @@ module Installations
     end
 
     def capture_foreign_keys
-      struct.blueprint_identifier = blueprint&.identifier
+      struct.blueprint_identifier ||= blueprint&.identifier
     end
 
   end


### PR DESCRIPTION
…on subsequent saves