### PR TITLE
strip module names from file names

### DIFF
--- a/ruby/docker/images/space.rb
+++ b/ruby/docker/images/space.rb
@@ -38,7 +38,7 @@ module Docker
 
       def default_options
         {
-          dockerfile: file_class.identifier,
+          dockerfile: file_class.qualifier,
           force: true,
           rm: true
         }

--- a/ruby/spaces/model.rb
+++ b/ruby/spaces/model.rb
@@ -53,7 +53,7 @@ module Spaces
     end
 
     def file_name
-      klass.identifier
+      klass.qualifier
     end
 
     def subpath; end

--- a/ruby/spaces/space.rb
+++ b/ruby/spaces/space.rb
@@ -71,7 +71,7 @@ module Spaces
     end
 
     def reading_name_for(descriptor, klass = default_model_class)
-      "#{path}/#{descriptor.identifier}/#{klass.identifier}"
+      "#{path}/#{descriptor.identifier}/#{klass.qualifier}"
     end
 
     def writing_name_for(model)


### PR DESCRIPTION
requires blowing away UniversalSpace and re-importing of blueprints