### PR TITLE
Add blueprint method to DescriptiveSubdivision.

### DIFF
--- a/src/engines/emitting/emissions/descriptive_subdivision.rb
+++ b/src/engines/emitting/emissions/descriptive_subdivision.rb
@@ -9,6 +9,10 @@ module Emissions
       @resolution ||= universe.resolutions.by(identifier)
     end
 
+    def blueprint
+      @blueprint ||= universe.blueprints.by(descriptor)
+    end
+
     def descriptor; @descriptor ||= descriptor_class.new(struct.descriptor) ;end
     def identifier; struct.identifier || descriptor.identifier ;end
 


### PR DESCRIPTION
 Allows binding to find its targeted blueprint.