### PR TITLE
Spaces::Thing :to_json method accepts arguments

### DIFF
--- a/src/spaces/models/thing.rb
+++ b/src/spaces/models/thing.rb
@@ -42,7 +42,7 @@ module Spaces
 
     def context_identifier; identifier ;end
     def to_yaml; YAML.dump(struct) ;end
-    def to_json; struct&.to_h_deep&.to_json ;end
+    def to_json(*args); struct&.to_h_deep&.to_json(*args) ;end
     def open_struct_from_json(j); JSON.parse(j, object_class: OpenStruct) ;end
 
     def to_s; identifier ;end


### PR DESCRIPTION
Custom to_json methods need to accept arguments in order to support nested objects.