### PR TITLE
Index provisioning by areana or resolution. Don't test domains or tenants.

### DIFF
--- a/api/arenas.rb
+++ b/api/arenas.rb
@@ -2,10 +2,9 @@ require './api/helpers/topology'
 
 # Show provisioning for an arena.
 get '/arenas/:identifier/provisioning' do
-  provisions_identifiers = universe.provisioning.identifiers(params[:identifier])
-  provisions_identifiers.map do |identifier|
-    universe.provisioning.by(identifier)
-  end.to_json
+  universe.provisioning.identifiers(
+    arena_identifier: params[:identifier]
+  ).to_json
 end
 
 # Perform an action (:init, :plan or :apply) on an arena.

--- a/api/crud.rb
+++ b/api/crud.rb
@@ -6,8 +6,9 @@ get '/:space' do
 end
 
 # Show a member from a space
-get '/:space/:identifier' do
-  universe.send(params[:space]).by(params[:identifier]).to_json
+get '/:space/*' do
+  identifier = params[:splat][0]
+  universe.send(params[:space]).by(identifier).to_json
 end
 
 # Create a member in a space
@@ -22,19 +23,21 @@ post '/:space' do
 end
 
 # Update a member in a space
-put '/:space/:identifier' do
+put '/:space/*' do
   space = universe.send(params[:space])
   struct = JSON.parse(request.body.read).to_struct
-  klass = member_class_for(space)
+  klass = member_class_for(params[:space])
+  debugger
   object = klass.new(struct: struct)
   space.save(object)
   object.to_json
 end
 
 # Delete a member from a space
-delete '/:space/:identifier' do
+delete '/:space/*' do
+  identifier = params[:splat][0]
   space = universe.send(params[:space])
-  object = space.by(params[:identifier])
-  space.delete(arena)
+  object = space.by(identifier)
+  space.delete(object)
   nil.to_json
 end

--- a/api/provisioning.rb
+++ b/api/provisioning.rb
@@ -1,17 +1,11 @@
-# Show provisions
-get '/provisioning/:arena_identifier/:resolution_identifier' do
-  universe.provisioning.by(
-    "#{params[:arena_identifier]}/#{params[:resolution_identifier]}"
-  ).to_json
-rescue Errno::ENOENT
-  nil.to_json
-end
-
-# Delete provisions
-delete '/provisioning/:arena_identifier/:resolution_identifier' do
-  provisions = universe.provisioning.by(
-    "#{params[:arena_identifier]}/#{params[:resolution_identifier]}"
+# Create provisions
+post '/provisioning/:arena_identifier/:resolution_identifier' do
+  arena = universe.arenas.by(params[:arena_identifier])
+  resolution = universe.resolutions.by(params[:resolution_identifier])
+  universe.provisioning.save(
+    Provisioning::Provisions.new(
+      arena: arena,
+      resolution: resolution,
+    )
   )
-  universe.provisioning.delete(provisions)
-  nil.to_json
 end

--- a/api/resolutions.rb
+++ b/api/resolutions.rb
@@ -1,3 +1,10 @@
+# Show provisioning for a resolution.
+get '/resolutions/:identifier/provisioning' do
+  universe.provisioning.identifiers(
+    resolution_identifier: params[:identifier]
+  ).to_json
+end
+
 # Show validity for a resolution
 get '/resolutions/:identifier/validity' do
   resolution = universe.resolutions.by(params[:identifier])

--- a/test.rb
+++ b/test.rb
@@ -1,5 +1,4 @@
 require 'byebug'
-require 'fileutils'
 
 require './api/universe'
 require './tests/arenas'
@@ -14,15 +13,15 @@ require './tests/test'
 extend Tests
 
 # Clear all Spaces data
-FileUtils.rm_rf(Dir.glob('/opt/spaces/Universe/*'))
+Pathname.new("/opt/spaces/Universe").children.each(&:rmtree)
 
 # Create counters
 init
 
 # Perform tests
-tenants
+# tenants
 arenas
-domains
+# domains
 blueprints
 resolutions
 packing

--- a/tests/provisioning.rb
+++ b/tests/provisioning.rb
@@ -13,7 +13,10 @@ module Tests
       resolution = universe.resolutions.by(resolution_identifier)
 
       test "create #{identifier} provisions" do
-        output provisions = Provisioning::Provisions.new(resolution: resolution, arena: arena)
+        output provisions = Provisioning::Provisions.new(
+          resolution: resolution,
+          arena: arena
+        )
         output universe.provisioning.save(provisions)
       end
 
@@ -24,7 +27,19 @@ module Tests
       test "index includes #{identifier}" do
         output identifiers = universe.provisioning.identifiers
         raise "#{identifier} not created" unless
-        identifiers.map(&:to_s).include?(identifier)
+        identifiers.include?(identifier)
+      end
+
+      test "index resolution_provisions for #{resolution_identifier} resolution includes #{identifier}" do
+        output identifiers = universe.provisioning.identifiers(resolution_identifier: resolution_identifier)
+        raise "#{identifier} not shown in #{resolution_identifier}" unless
+        identifiers.include?(identifier)
+      end
+
+      test "index arena_provisions for #{arena_identifier} arena includes #{identifier}" do
+        output identifiers = universe.provisioning.identifiers(arena_identifier: arena_identifier)
+        raise "#{identifier} not shown in #{arena_identifier}" unless
+        identifiers.include?(identifier)
       end
 
       test 'delete' do
@@ -35,7 +50,7 @@ module Tests
       test 'index after delete' do
         output identifiers = universe.provisioning.identifiers
         raise "#{identifier} not deleted" if
-        identifiers.map(&:to_s).include?(identifier)
+        identifiers.include?(identifier)
       end
 
     end


### PR DESCRIPTION
Use named args for show provisioning for an arena.
Don't test tenants or domains for the time being.
Create provisions by passing in resolution and arena.
