### PR TITLE
FIX BUG: inflating bindings crashes with TypeError

### DIFF
--- a/src/engines/blueprinting/divisions/images/images.rb
+++ b/src/engines/blueprinting/divisions/images/images.rb
@@ -3,7 +3,5 @@ module Divisions
 
     def struct_with(other); super.uniq(&:image) ;end
 
-    def inflated_struct; all.map(&:inflated_struct) ;end
-
   end
 end

--- a/src/engines/transforming/divisions/divisible.rb
+++ b/src/engines/transforming/divisions/divisible.rb
@@ -36,6 +36,8 @@ module Divisions
       nil
     end
 
+    def inflated_struct; all.map(&:inflated_struct) ;end
+
     def resolved
       empty.tap { |d| d.struct = all.map(&:resolved).map(&:struct) }
     end


### PR DESCRIPTION
wrong element type OpenStruct at 0 (expected array)

Signed-off-by: Mark Ratjens <mark@ratjens.com>