### PR TITLE
FIX BUG: when initialising a resolution from a struct, it’s arena is lost

### DIFF
--- a/src/engines/resolving/resolution.rb
+++ b/src/engines/resolving/resolution.rb
@@ -12,10 +12,12 @@ module Resolving
 
     delegate(
       resolutions: :universe,
-      blueprints: :resolutions
+      [:arenas, :blueprints] => :resolutions
     )
 
     relation_accessor :arena
+    
+    def arena; @arena ||= arenas.by(arena_identifier) ;end
 
     def arena_identifier; identifier.split('/').first ;end
 
@@ -25,7 +27,7 @@ module Resolving
     def complete?
       all_complete?(divisions)
     end
-    
+
     def connections_resolved
       connections.map { |c| c.with_embeds.resolved_in(arena) }
     end


### PR DESCRIPTION
NoMethodError (undefined method `struct' for nil:NilClass)

Signed-off-by: Mark Ratjens <mark@ratjens.com>