### PR TITLE
ensure spurious blueprint divisions don’t pollute resolutions

### DIFF
--- a/lib/spaces/engines/transforming/emissions/hashing.rb
+++ b/lib/spaces/engines/transforming/emissions/hashing.rb
@@ -2,13 +2,13 @@ module Emissions
   module Hashing
 
     def to_h
-      keys.inject({}) do |m, k|
+      division_map.keys.inject({}) do |m, k|
         m.tap { m[k] = h_for(k) }
       end.compact
     end
 
     def h_for(key)
-      (division_map[key] || struct[key]).to_h
+      division_map[key]&.to_h
     end
 
   end


### PR DESCRIPTION
and subsequent emissions

Signed-off-by: Mark Ratjens <mark@ratjens.com>