### PR TITLE
Arena merging for configurations

### DIFF
--- a/lib/spaces/commands/arenas/configuring.rb
+++ b/lib/spaces/commands/arenas/configuring.rb
@@ -1,0 +1,17 @@
+require_relative 'saving'
+
+module Arenas
+  module Commands
+    class Configuring < Saving
+
+      def model
+        @model ||= super.merge(configuration)
+      end
+
+      def configuration
+        @configuration ||= ::Spaces::Commands::Reading.new(identifier: input[:configuration_identifier], space: :configurations).run.result
+      end
+
+    end
+  end
+end

--- a/lib/spaces/engines/arenas/composition.rb
+++ b/lib/spaces/engines/arenas/composition.rb
@@ -11,6 +11,7 @@ module Arenas
 
       def division_classes
         [
+          Divisions::Configuration,
           Divisions::Bindings,
           Divisions::About
         ]

--- a/lib/spaces/engines/transforming/divisions/divisible.rb
+++ b/lib/spaces/engines/transforming/divisions/divisible.rb
@@ -54,6 +54,7 @@ module Divisions
     end
 
     def struct_with(other); [struct, other.struct].flatten.uniq ;end
+    alias_method :merge, :struct_with
 
     def initialize(struct: nil, emission: nil, label: nil)
       check_subdivision_class

--- a/lib/spaces/engines/transforming/divisions/division.rb
+++ b/lib/spaces/engines/transforming/divisions/division.rb
@@ -80,6 +80,8 @@ module Divisions
       empty.tap { |s| s.struct = OpenStruct.new(deflatables) }
     end
 
+    def merge(other); struct.merge(other.struct) ;end
+
     def initialize(emission:, struct: nil, label: nil)
       self.emission = emission
       self.label = label

--- a/lib/spaces/engines/transforming/emissions/emission.rb
+++ b/lib/spaces/engines/transforming/emissions/emission.rb
@@ -6,6 +6,7 @@ require_relative 'binding'
 require_relative 'topology'
 require_relative 'embedding'
 require_relative 'resolving'
+require_relative 'merging'
 require_relative 'hashing'
 
 module Emissions
@@ -19,6 +20,7 @@ module Emissions
     include Topology
     include Embedding
     include Resolving
+    include Merging
     include Hashing
 
     class << self

--- a/lib/spaces/engines/transforming/emissions/merging.rb
+++ b/lib/spaces/engines/transforming/emissions/merging.rb
@@ -1,0 +1,22 @@
+module Emissions
+  module Merging
+
+    def merge(other)
+      empty.tap do |m|
+        m.predecessor = self
+        m.struct = m.struct.merge(OpenStruct.new(merging_division_map(other)))
+      end
+    end
+
+    def merging_division_map(other)
+      merging_keys(other).inject({}) do |m, k|
+        m.tap { m[k] = division_for(k).merge(other.division_for(k)) }
+      end
+    end
+
+    def merging_keys(other)
+      @merging_keys ||= [division_keys, other.division_keys].flatten.uniq
+    end
+
+  end
+end

--- a/lib/spaces/providers/virtualisation/lxd/lxd.rb
+++ b/lib/spaces/providers/virtualisation/lxd/lxd.rb
@@ -20,9 +20,9 @@ module Providers
       %(
         lxd_remote {
           name     = "lxd-server"
-          scheme   = "https"
-          address  = "192.168.20.220"
-          password = "#{configuration.password}"
+          scheme   = "#{arena.configuration.scheme}"
+          address  = "#{arena.configuration.address}"
+          password = "#{arena.configuration.password}"
           default  = true
         }
       )

--- a/lib/spaces/universe.rb
+++ b/lib/spaces/universe.rb
@@ -17,6 +17,7 @@ class Universe < ::Spaces::Model
         Packing::Space.new(:packs),
         Provisioning::Space.new(:provisioning),
         Arenas::Space.new(:arenas),
+        Arenas::Space.new(:configurations),
 
         Associations::Domains::Space.new(:domains),
         Associations::Tenants::Space.new(:tenants)

--- a/x/scripts.rb
+++ b/x/scripts.rb
@@ -9,6 +9,17 @@ require 'spaces'
 
 universe = Universe.universe
 
+#set up an arena configuration
+params = {
+  identifier: 'an_arena_config',
+  configuration: {
+    scheme: 'https',
+    address: '192.168.20.220',
+    password: 'zinfandel'
+  }
+}
+Spaces::Commands::Saving.new(identifier: 'an_arena_config', model: params, space: :configurations).run.payload
+
 # import a bootstrappy blueprint
 Publishing::Commands::Importing.new(
   model: {repository: 'https://github.com/v2Blueprints/arena'},
@@ -26,6 +37,9 @@ Spaces::Commands::Deleting.new(identifier: :development, space: :arenas).run.pay
 
 # save a basic arena with default associations
 Arenas::Commands::Saving.new(identifier: :development).run.payload
+
+# configure the basic arena with the configuration we already set up
+Arenas::Commands::Configuring.new(identifier: :development, configuration_identifier: :an_arena_config).run.payload
 
 # bind the blueprint to the arena
 Arenas::Commands::Binding.new(identifier: :development, blueprint_identifier: :arena).run.payload


### PR DESCRIPTION
There's now a configuration space to hold 'template' arenas which are intended to hold a configuration division which can be merged into any operational arena.