### PR TITLE
FIX BUG: OpenStruct#to_json returns rubbish result

### DIFF
--- a/lib/spaces/spaces/lib/ostruct.rb
+++ b/lib/spaces/spaces/lib/ostruct.rb
@@ -18,6 +18,10 @@ class OpenStruct
 
   def keys; to_h.keys ;end
 
+  def to_json
+    to_h_deep.to_json
+  end
+
   def to_h_deep
     to_h.transform_values do |v|
       v.to_h_deep


### PR DESCRIPTION
e.g "\"#<OpenStruct descriptor=#<OpenStruct identifier=\\\"phpmyadmin\\\">, blueprint={:exist=>true}>\""

Signed-off-by: Mark Ratjens <mark@ratjens.com>