### PR TITLE
FIX REGRESSION: NoMethodError (undefined method `runtime' Binding)

### DIFF
--- a/lib/spaces/engines/transforming/divisions/bindings/binding.rb
+++ b/lib/spaces/engines/transforming/divisions/bindings/binding.rb
@@ -15,11 +15,13 @@ module Divisions
       def features; [:type, :identifier, :target_identifier, :configuration] ;end
     end
 
+    def runtime; struct.runtime ;end
+
     def type; struct.type || derived_features[:type] ;end
 
     def embed?; type == 'embed' ;end
 
-    def for_runtime?(value); [value, nil].include?(struct.runtime) ;end
+    def for_runtime?(value); [value, nil].include?(runtime) ;end
 
     def runtime_binding?; ['runtime', 'containing'].include?(identifier) ;end
     def packing_binding?; ['packing'].include?(identifier) ;end


### PR DESCRIPTION
broken when changing retuirn type of Divisible#transformed_to in 3d1471d7be119ee9ec5f0664a4f6b58a521258af

Signed-off-by: Mark Ratjens <mark@ratjens.com>