### PR TITLE
FIX BUGS: Arenas::Settling#unsaved crashing with mis-named method calls

### DIFF
--- a/lib/spaces/engines/arenas/installing.rb
+++ b/lib/spaces/engines/arenas/installing.rb
@@ -7,7 +7,7 @@ module Arenas
     def installed; present_in(installations) ;end
     def uninstalled; absent_in(installations) ;end
 
-    def unsaved_installations; unsaved(:installation) ;end
+    def unsaved_installations; unsaved(:installations) ;end
     def bound_installations; installation_map.values ;end
 
     def installation_map; bound_map_for(:installation) ;end

--- a/lib/spaces/engines/arenas/settling.rb
+++ b/lib/spaces/engines/arenas/settling.rb
@@ -11,8 +11,8 @@ module Arenas
     end
 
     def unsaved(bound_key)
-      bound_of(bound_key.singularized).reject do |s|
-        space_for(bound_key).exist?(s)
+      bound_of(bound_key.singularize).reject do |s|
+        space_named(bound_key).exist?(s)
       end
     end
 


### PR DESCRIPTION
singularized should be singularize
space_for should be space_named

Signed-off-by: Mark Ratjens <mark@ratjens.com>