### PR TITLE
FIX BUG: importing bindings crashes because the wrong file name is written

### DIFF
--- a/lib/spaces/engines/locating/space.rb
+++ b/lib/spaces/engines/locating/space.rb
@@ -10,7 +10,9 @@ module Locating
     alias_method :identifiers, :simple_identifiers
 
     def ensure_located(publication)
-      publication.bindings.descriptors.each { |d| save(d) unless exist?(d)}
+      publication.bindings.descriptors.each do |d|
+        save(default_model_class.new(d.struct)) unless exist?(d)
+      end
     end
 
   end


### PR DESCRIPTION


should be location.yaml not descriptor.yaml

Signed-off-by: Mark Ratjens <mark@ratjens.com>