### PR TITLE
FIX: container exec call passes bad ENV params

### DIFF
--- a/lib/spaces/models/emissions/commissioning/service.rb
+++ b/lib/spaces/models/emissions/commissioning/service.rb
@@ -20,9 +20,7 @@ module Commissioning
     end
 
     def commands_for(name)
-      milestones_for(name).map do |m|
-        ["#{m.path}", parameters].flatten
-      end
+      milestones_for(name).map { |m| "#{m.path}" }
     end
 
     def milestones_for(name)

--- a/lib/spaces/providers/docker/interfaces/service_interface.rb
+++ b/lib/spaces/providers/docker/interfaces/service_interface.rb
@@ -10,7 +10,7 @@ module Providers
         wait_for
         wait_for(:startup)
         service.commands_for(milestone_name).map do |c|
-          container.exec(c)
+          container.exec([c], env: service.parameters)
         end
       end
 


### PR DESCRIPTION
Signed-off-by: Mark Ratjens <mark@ratjens.com>