### PR TITLE
abbreviate terraform resource identifiers

### DIFF
--- a/lib/spaces/framework/lib/abbreviating.rb
+++ b/lib/spaces/framework/lib/abbreviating.rb
@@ -1,0 +1,34 @@
+module Abbreviating
+
+  def abbreviated_to(l, separator = '-')
+    s = abbreviation_methods(l, separator).reduce(self) do |m, args|
+      m.length > l ? m.send(*args) : m
+    end
+  end
+
+  def abbreviation_methods(l, separator = '-')
+    [
+      [:no_vowels_except_after, separator],
+      [:segments_trancated_to, 4],
+      [:without_delimiter, separator],
+      [:[], 0, l - 1]
+    ]
+  end
+
+  def no_vowels_except_after(separator) =
+    split(separator).map(&:no_nonleading_vowels).join(separator)
+
+  def segments_trancated_to(l, separator = '-')
+    split(separator).map do |s|
+      s.integer? ? s.reverse : s[0, l]
+    end.join(separator)
+  end
+
+  def no_nonleading_vowels =
+    length > 4 ? "#{chr}#{self[1..-1].no_vowels}" : self
+
+  def no_vowels = gsub(/[aeiouy]/i, '')
+  def integer? = to_i.to_s == self
+  def without_delimiter(separator = '-') = gsub(separator, '')
+
+end

--- a/lib/spaces/framework/lib/string.rb
+++ b/lib/spaces/framework/lib/string.rb
@@ -1,7 +1,9 @@
 require_relative 'identifiable'
+require_relative 'abbreviating'
 
 class String
   include Identifiable
+  include Abbreviating
 
   BLANK_RE = /\A[[:space:]]*\z/
 

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_registry.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_registry.rb
@@ -46,7 +46,7 @@ module Artifacts
 
         def push_images_snippet =
           %(
-            resource "null_resource" "#{resource_identifier}-images-#{Time.now.to_i}" {
+            resource "null_resource" "#{images_resource_identifier}" {
               provisioner "local-exec" {
                 command = <<LINES
                   #{login_command} &&
@@ -59,6 +59,9 @@ module Artifacts
               ]
             }
           )
+
+        def images_resource_identifier =
+          "#{resource_identifier}-images-#{Time.now.to_i}".abbreviated_to(32)
 
         def image_push_commands
           arena.compute_resolutions_for(:container_service).map do |r|

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_service.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_service.rb
@@ -19,6 +19,7 @@ module Artifacts
         def default_configuration =
           super.merge(
             desired_count: emission.dimensions&.tasks || 1,
+            security_group_binding: :security_group,
             task_definition_binding: default_binding,
             target_group_binding: default_binding,
             subnet_binding: default_binding,
@@ -42,6 +43,7 @@ module Artifacts
             }
             network_configuration {
               subnets = [aws_subnet.#{qualification_for(:subnet_binding)}.id]
+              security_groups = [aws_security_group.#{qualification_for(:security_group_binding)}.id]
             }
           )
 

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_task_definition.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_task_definition.rb
@@ -10,7 +10,8 @@ module Artifacts
             super.merge(
               network_mode: :awsvpc,
               memory: 2048,
-              cpus: 1024
+              cpus: 1024,
+              role_binding: :'iam-role'
             )
         end
 
@@ -25,6 +26,7 @@ module Artifacts
 
         def more_snippets =
           %(
+            execution_role_arn = aws_iam_role.#{qualification_for(:role_binding)}.arn
             requires_compatibilities = #{compatibilities}
             container_definitions = jsonencode([
               #{definition_snippets}

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_task_definition.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/container_task_definition.rb
@@ -58,7 +58,7 @@ module Artifacts
         def hash_for(r) =
           {
             name: r.image_identifier.hyphenated,
-            image: r.image_identifier,
+            image: "#{arena.compute_repository_path}:#{r.image_identifier}",
             essential: true
           }.
             merge(dimensions_hash_for(r))

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/resource.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/stanzas/resource.rb
@@ -25,7 +25,7 @@ module Artifacts
 
         alias_method :resource, :holder
 
-        def resource_identifier = [arena.identifier, resource.identifier].join('-').hyphenated
+        def resource_identifier = [arena.identifier, resource.identifier].join('-').hyphenated.abbreviated_to(32)
 
         def resource_type_here =
           resource_type_map[resource_type.to_sym] || resource_type


### PR DESCRIPTION
if necessary
(they can’t be longer than 32 characters)

Signed-off-by: Mark Ratjens <mark@ratjens.com>