### PR TITLE
FIX BUG: ERROR - Streaming::OutputStream:  wrong number of arguments

### DIFF
--- a/lib/spaces/framework/asserting/errors.rb
+++ b/lib/spaces/framework/asserting/errors.rb
@@ -4,7 +4,7 @@ module Spaces
 
       attr_reader :diagnostics
 
-      def initialize(args)
+      def initialize(**args)
         super
         @diagnostics = {self.class.name => args}
       end


### PR DESCRIPTION
initialize(args) should be initialize(**args), because ruby 3 is dumber about keyword arguments

Signed-off-by: Mark Ratjens <mark@ratjens.com>