### PR TITLE
FIX BUG: `dynamic_type': wrong number of arguments

### DIFF
--- a/lib/spaces/models/adapters/repositories/repositories.rb
+++ b/lib/spaces/models/adapters/repositories/repositories.rb
@@ -7,8 +7,5 @@ module Adapters
 
     delegate(subadapter_class: :klass)
 
-    def subadapter_for(subdivision) =
-      subadapter_class.dynamic_type(subdivision)
-
   end
 end

--- a/lib/spaces/models/adapters/repositories/repository.rb
+++ b/lib/spaces/models/adapters/repositories/repository.rb
@@ -4,8 +4,8 @@ module Adapters
   class Repository < PackageAccess
 
     class << self
-      def dynamic_type(division) =
-        class_for(division.type).new(division)
+      def dynamic_type(division, adapter) =
+        class_for(division.type).new(division, adapter)
 
       def class_for(type) = super(:adapters, type.to_s.camelize, qualifier)
     end


### PR DESCRIPTION
when trying to instantiate a repository adapter

Signed-off-by: Mark Ratjens <mark@ratjens.com>