### PR TITLE
FIX BUG: “more” attributes duplicated in HCL

### DIFF
--- a/lib/spaces/commands/packing/building.rb
+++ b/lib/spaces/commands/packing/building.rb
@@ -7,16 +7,6 @@ module Packing
 
       def instruction = :build
 
-      def payload
-        return super unless result&.class == Packer::Output::Build
-
-        if (e = result.errors).any?
-          { errors: e.map(&:error) }
-        else
-          { result: result.artifacts.map(&:string) }
-        end
-      end
-
     end
   end
 end

--- a/lib/spaces/models/adapters/repositories/repositories.rb
+++ b/lib/spaces/models/adapters/repositories/repositories.rb
@@ -7,5 +7,8 @@ module Adapters
 
     delegate(subadapter_class: :klass)
 
+    def subadapter_for(subdivision) =
+      subadapter_class.dynamic_type(subdivision, self)
+
   end
 end

--- a/lib/spaces/models/transforming/adapters/division.rb
+++ b/lib/spaces/models/transforming/adapters/division.rb
@@ -6,6 +6,8 @@ module Adapters
     relation_accessor :division
     relation_accessor :adapter
 
+    delegate(struct: :division)
+
     def snippet_map
       @snippet_map ||= {}.tap { |m| m[qualifier] = snippets }.compact
     end

--- a/lib/spaces/providers/aws/artifacts/stanzas/acm_certificate.rb
+++ b/lib/spaces/providers/aws/artifacts/stanzas/acm_certificate.rb
@@ -1,0 +1,14 @@
+require_relative 'resource'
+
+module Artifacts
+  module Aws
+    module Stanzas
+      class AcmCertificate < Resource
+
+        def more_snippets_keys =
+          [:domain_name, :validation_method, :create_before_destroy]
+
+      end
+    end
+  end
+end

--- a/lib/spaces/providers/aws/artifacts/stanzas/stanzas.rb
+++ b/lib/spaces/providers/aws/artifacts/stanzas/stanzas.rb
@@ -4,7 +4,6 @@ module Artifacts
   module Aws
     module Stanzas
 
-      class AcmCertificate < Resource ;end
       class ContainerDefinition < Resource ;end
       class ContainerServiceCluster < Resource ;end
       class IamRole < Resource ;end

--- a/lib/spaces/providers/terraform/providers/aws/artifacts/formats/acm_certificate.rb
+++ b/lib/spaces/providers/terraform/providers/aws/artifacts/formats/acm_certificate.rb
@@ -17,9 +17,6 @@ module Artifacts
               }
             )
 
-          def more_snippets_keys =
-            [:domain_name, :validation_method, :create_before_destroy]
-
         end
       end
     end


### PR DESCRIPTION
│ Error: Attribute redefined
│
│ On startup-service-cluster.resources.tf line 60: The argument "domain_name" │ was already set at startup-service-cluster.resources.tf:53,3-14. Each │ argument may be set only once.

Signed-off-by: Mark Ratjens <mark@ratjens.com>