### PR TITLE
Exceptions should go to stream for background commands only.

### DIFF
--- a/lib/spaces/framework/streaming/output_stream.rb
+++ b/lib/spaces/framework/streaming/output_stream.rb
@@ -21,10 +21,6 @@ module Streaming
     # The << method is so stream behaves like STDOUT
     def << (line) = output(line)
 
-    def exception
-      # Do nothing. Exception logged elsewhere.
-    end
-
     def output(line) =
       verbose? ? print(line) : progress_line(line)
 

--- a/lib/spaces/framework/streaming/producing.rb
+++ b/lib/spaces/framework/streaming/producing.rb
@@ -4,8 +4,12 @@ module Streaming
     def produce(&block)
       yield(self)
     rescue => e
-      logger.error(e)
-      exception(e)
+      # logger.error(e)
+      if command.input[:background]
+        exception(e) 
+      else
+        raise e
+      end 
     end
 
     def output_lines_from(io)


### PR DESCRIPTION
Exceptions should raise when command not in background.